### PR TITLE
SARS-CoV-2 : ShoRAH 2.x , etc.

### DIFF
--- a/envs/snv.yaml
+++ b/envs/snv.yaml
@@ -3,5 +3,5 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - shorah
+  - shorah >=1.99.0
   - bcftools

--- a/vpipe.snake
+++ b/vpipe.snake
@@ -1548,7 +1548,7 @@ rule snv:
             # Change to the directory where ShoRAH is to be executed
             cd ${{DIR}}
 
-            # NOTE: Execution command for ShoRAH2, not yet in bioconda
+            # NOTE: Execution command for ShoRAH2 valid from v1.99.0 and above
             {params.SHORAH} -w ${{WINDOW_LEN}} -x 100000 -r ${{region}} -R 42 -b ${{BAM}} -f ${{REF}} >> $OUTFILE 2> >(tee -a $ERRFILE >&2)
             {params.BCFTOOLS} view ${{DIR}}/snv/SNVs_0.010000_final.vcf -Oz -o ${{DIR}}/snv/SNVs_0.010000_final.vcf.gz
             {params.BCFTOOLS} index ${{DIR}}/snv/SNVs_0.010000_final.vcf.gz

--- a/vpipe.snake
+++ b/vpipe.snake
@@ -559,6 +559,15 @@ if config.input['paired']:
 
             {params.PRINSEQ} -fastq {input.R1} -fastq2 {input.R2} -out_format 3 -out_good {wildcards.dataset}/preprocessed_data/R -out_bad null -ns_max_n 4 -min_qual_mean 30 -trim_qual_left 30 -trim_qual_right 30 -trim_qual_window 10 -min_len {params.LEN_CUTOFF} -log {log.outfile} 2> >(tee {log.errfile} >&2)
 
+            # make sure that the lock held prinseq has been effectively released and propagated
+            # on some networked shares this could otherwise lead to confusion or corruption
+            if [[ "$OSTYPE" =~ ^linux ]]; then
+                echo "Waiting for unlocks" >&2
+                for U in {wildcards.dataset}/preprocessed_data/R_{{1,2}}.fastq; do
+                    flock -x -o ${{U}} -c "echo ${{U}} unlocked >&2"
+                done
+            fi
+
             mv {wildcards.dataset}/preprocessed_data/R{{_,}}1.fastq
             mv {wildcards.dataset}/preprocessed_data/R{{_,}}2.fastq
             rm -f {wildcards.dataset}/preprocessed_data/R_?_singletons.fastq
@@ -593,6 +602,15 @@ else:
 
             {params.PRINSEQ} -fastq {input.R1} -out_format 3 -out_good {wildcards.dataset}/preprocessed_data/R -out_bad null -ns_max_n 4 -min_qual_mean 30 -trim_qual_left 30 -trim_qual_right 30 -trim_qual_window 10 -min_len {params.LEN_CUTOFF} -log {log.outfile} 2> >(tee {log.errfile} >&2)
 
+            # make sure that the lock held prinseq has been effectively released and propagated
+            # on some network shares this could otherwise lead to confusion or corruption
+            if [[ "$OSTYPE" =~ ^linux ]]; then
+                echo "Waiting for unlocks" >&2
+                for U in {wildcards.dataset}/preprocessed_data/R_{{1,2}}.fastq; do
+                    flock -x -o ${{U}} -c "echo ${{U}} unlocked >&2"
+                done
+            fi
+            
             mv {wildcards.dataset}/preprocessed_data/R{{,1}}.fastq
 
             gzip {wildcards.dataset}/preprocessed_data/R1.fastq


### PR DESCRIPTION
- ShoRAH 2.x introduced (v1.99.0)
- smallgenomeutilities bumped to 0.3.0
  - (the above currently rely on the BiocondaBot's `please fetch artifacts`: [smallgenomeutilities](https://github.com/bioconda/bioconda-recipes/pull/21240#issuecomment-607537053), [shorah](https://github.com/bioconda/bioconda-recipes/pull/21245#issuecomment-607668919) )
- `flock` made linux-specific
  
  (it's the most likely environment to have a grid filesystem with distributed lock management, anyway. Apple Xserve machine aren't a thing since 2011)
