### PR TITLE
smallgenomeutilities 0.3.1 : 'N' in consensus

### DIFF
--- a/rules/align.smk
+++ b/rules/align.smk
@@ -563,6 +563,7 @@ rule consensus_sequences:
         mem = config.consensus_sequences['mem'],
         time = config.consensus_sequences['time'],
         MIN_COVERAGE = config.consensus_sequences['min_coverage'],
+        N_COVERAGE = config.consensus_sequences['n_coverage'],
         QUAL_THRD = config.consensus_sequences['qual_thrd'],
         MIN_FREQ = config.consensus_sequences['min_freq'],
         OUTDIR = "{dataset}/references",
@@ -582,7 +583,7 @@ rule consensus_sequences:
         CONSENSUS_NAME="${{CONSENSUS_NAME#*/}}"
         CONSENSUS_NAME="${{CONSENSUS_NAME//\//-}}"
 
-        {params.EXTRACT_CONSENSUS} -i {input.BAM} -f {input.REF} -c {params.MIN_COVERAGE} -q {params.QUAL_THRD} -a {params.MIN_FREQ} -n 2 -N "${{CONSENSUS_NAME}}" -o {params.OUTDIR}
+        {params.EXTRACT_CONSENSUS} -i {input.BAM} -f {input.REF} -c {params.MIN_COVERAGE} -n {params.N_COVERAGE} -q {params.QUAL_THRD} -a {params.MIN_FREQ} -N "${{CONSENSUS_NAME}}" -o {params.OUTDIR}
         """
 
 

--- a/rules/config_default.smk
+++ b/rules/config_default.smk
@@ -201,6 +201,7 @@ class VpipeConfig(object):
             'conda': __RECORD__(value=f'{VPIPE_BASEDIR}/envs/smallgenomeutilities.yaml', type=str),
 
             'min_coverage': __RECORD__(value=50, type=int),
+            'n_coverage': __RECORD__(value=5, type=int),
             'qual_thrd': __RECORD__(value=15, type=int),
             'min_freq': __RECORD__(value=0.05, type=float),
         }),


### PR DESCRIPTION
Updated the old #52 pull request against master.
- N options can be specified in config file.

I'm not married to the default value of 5 (as long as it is selectable).

Experience (both past in other work settings and current with SARS-CoV-2 sequencing) tends to show that on very large sequencing project having a few stray contaminant that pile to coverage 3 or 4 isn't completely unhead of.
Having the N threshold set in stone at 2 would produce a lot of false positive due to contaminants.

See example: [EMPTY_CP003_F5-20200427_CTT3D.html.gz](https://github.com/cbg-ethz/V-pipe/files/4809520/EMPTY_CP003_F5-20200427_CTT3D.html.gz)
(In this peculiar examples, it even goes above 5. Most of the time it is around the 3 range)