### PR TITLE
Update ShoRAH 1.99.2

### DIFF
--- a/envs/snv.yaml
+++ b/envs/snv.yaml
@@ -3,5 +3,5 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - shorah=1.99.0
-  - bcftools=1.9
+  - shorah=1.99.2
+  - bcftools=1.10.2

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -138,7 +138,7 @@ for p in patient_list:
         if config.general['snv_caller'] == 'shorah':
             results.append("{sample_dir}/{patient}/{date}/variants/SNVs/snvs.csv".format(
                 sample_dir=config.input['datadir'], patient=p.patient_id, date=p.date))
-        # all aligners ('shorah', 'lofreq') produce standard VCF files
+        # all snv callers ('shorah', 'lofreq') produce standard VCF files
         results.append("{sample_dir}/{patient}/{date}/variants/SNVs/snvs.vcf".format(
             sample_dir=config.input['datadir'], patient=p.patient_id, date=p.date))
     # local haplotypes

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -134,12 +134,13 @@ for p in patient_list:
 
     # SNV
     if config.output['snv']:
+        # in adition to standard VCF files, ShoRAH2 also produces CSV tables
         if config.general['snv_caller'] == 'shorah':
             results.append("{sample_dir}/{patient}/{date}/variants/SNVs/snvs.csv".format(
                 sample_dir=config.input['datadir'], patient=p.patient_id, date=p.date))
-        elif config.general['snv_caller'] == 'lofreq':
-            results.append("{sample_dir}/{patient}/{date}/variants/SNVs/snvs.vcf".format(
-                sample_dir=config.input['datadir'], patient=p.patient_id, date=p.date))
+        # all aligners ('shorah', 'lofreq') produce standard VCF files
+        results.append("{sample_dir}/{patient}/{date}/variants/SNVs/snvs.vcf".format(
+            sample_dir=config.input['datadir'], patient=p.patient_id, date=p.date))
     # local haplotypes
     if config.output['local']:
         results.append(

--- a/rules/config_default.smk
+++ b/rules/config_default.smk
@@ -233,6 +233,7 @@ class VpipeConfig(object):
             'consensus': __RECORD__(value=True, type=bool),
             'alpha': __RECORD__(value=0.1, type=float),
             'ignore_indels': __RECORD__(value=False, type=bool),
+            'posterior_threshold': __RECORD__(value=0.9, type=float),
             'coverage': __RECORD__(value=0, type=int),
             'shift': __RECORD__(value=3, type=int),
             'keep_files': __RECORD__(value=False, type=bool),

--- a/rules/snv.smk
+++ b/rules/snv.smk
@@ -95,7 +95,6 @@ rule snv:
         WORK_DIR = "{dataset}/variants/SNVs",
         LOCALSCRATCH = config.snv['localscratch'],
         SHORAH = config.applications['shorah'],
-        THREADS = config.snv['threads'],
         POSTHRESH = config.snv['posterior_threshold'],
         COVINT = config.coverage_intervals['coverage'],
         BCFTOOLS = config.applications['bcftools']
@@ -166,7 +165,7 @@ rule snv:
             fi
 
             # NOTE: Execution command for ShoRAH2 valid from v1.99.0 and above
-            {params.SHORAH} -t {params.THREADS} -a {params.ALPHA} -w ${{WINDOW_LEN}} -x 100000 {params.IGNORE_INDELS} -p {params.POSTHRESH} -c {params.COVERAGE} -r ${{region}} -R 42 -b ${{BAM}} -f ${{REF}} >> $OUTFILE 2> >(tee -a $ERRFILE >&2)
+            {params.SHORAH} -t {threads} -a {params.ALPHA} -w ${{WINDOW_LEN}} -x 100000 {params.IGNORE_INDELS} -p {params.POSTHRESH} -c {params.COVERAGE} -r ${{region}} -R 42 -b ${{BAM}} -f ${{REF}} >> $OUTFILE 2> >(tee -a $ERRFILE >&2)
             if [[ -n "{params.LOCALSCRATCH}" ]]; then
                 # copyback from localscratch
                 rsync -auq "{params.LOCALSCRATCH}/REGION_${{LINE_COUNTER}}" "${{WORK_DIR}}"

--- a/rules/snv.smk
+++ b/rules/snv.smk
@@ -95,6 +95,8 @@ rule snv:
         WORK_DIR = "{dataset}/variants/SNVs",
         LOCALSCRATCH = config.snv['localscratch'],
         SHORAH = config.applications['shorah'],
+        THREADS = config.snv['threads'],
+        POSTHRESH = config.snv['posterior_threshold'],
         COVINT = config.coverage_intervals['coverage'],
         BCFTOOLS = config.applications['bcftools']
     log:
@@ -164,7 +166,7 @@ rule snv:
             fi
 
             # NOTE: Execution command for ShoRAH2 valid from v1.99.0 and above
-            {params.SHORAH} -a {params.ALPHA} -w ${{WINDOW_LEN}} -x 100000 {params.IGNORE_INDELS} -c {params.COVERAGE} -r ${{region}} -R 42 -b ${{BAM}} -f ${{REF}} >> $OUTFILE 2> >(tee -a $ERRFILE >&2)
+            {params.SHORAH} -t {params.THREADS} -a {params.ALPHA} -w ${{WINDOW_LEN}} -x 100000 {params.IGNORE_INDELS} -p {params.POSTHRESH} -c {params.COVERAGE} -r ${{region}} -R 42 -b ${{BAM}} -f ${{REF}} >> $OUTFILE 2> >(tee -a $ERRFILE >&2)
             if [[ -n "{params.LOCALSCRATCH}" ]]; then
                 # copyback from localscratch
                 rsync -auq "{params.LOCALSCRATCH}/REGION_${{LINE_COUNTER}}" "${{WORK_DIR}}"


### PR DESCRIPTION
This new versions introduces:

 - posterior values strictly in the (0.0;1.0] range
 - does not crash on empty reads in the region (e.g.: when procesing negative controls).
 - avoid unhandled underflow exception in GSL (actually avoiding GSL entirely). 
 - parameter to control the number of threads in ShoRAH<br />(was: ncpus-1, which is problematic on 128-core monsters like the latest AMD EPYC Threadrippers)
 - parameter to change the posterior threshold used when calling SNVs (default: .9)
 - HTSlib API changed to a new version that doesn't cause crashes with HTSlib 1.10 (which incidentally introduces support for cram files)<br />(BTW, the bioconda package of 1.99.0 was also changed to pin its HTSlib dependencies to strictly 1.9)
 