### PR TITLE
Add HIV annotations to the visualization

### DIFF
--- a/references/gffs/GCF_000864765.1_ViralProj15476_genomic.gff
+++ b/references/gffs/GCF_000864765.1_ViralProj15476_genomic.gff
@@ -1,0 +1,40 @@
+##gff-version 3
+#!gff-spec-version 1.21
+#!processor NCBI annotwriter
+#!genome-build ViralProj15476
+#!genome-build-accession NCBI_Assembly:GCF_000864765.1
+##sequence-region NC_001802.1 1 9181
+##species https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=11676
+NC_001802.1	RefSeq	region	1	9181	.	+	.	ID=NC_001802.1:1..9181;Dbxref=taxon:11676;gb-acronym=HIV-1;gbkey=Src;genome=genomic;mol_type=genomic RNA;note=strain for reference annotation
+NC_001802.1	RefSeq	region	1	96	.	+	.	ID=id-NC_001802.1:1..96;Note=repeat%3B positions of RNA transcription initialization and polyadenylation;gbkey=Region
+NC_001802.1	RefSeq	polyA_signal_sequence	73	78	.	+	.	ID=id-NC_001802.1:73..78;Note=both 5' and 3' poly A signals are transcribed into RNA%2C but the 5' one is suppressed;gbkey=regulatory;regulatory_class=polyA_signal_sequence
+NC_001802.1	RefSeq	five_prime_UTR	97	181	.	+	.	ID=id-NC_001802.1:97..181;gbkey=5'UTR
+NC_001802.1	RefSeq	primer_binding_site	182	199	.	+	.	ID=id-NC_001802.1:182..199;gbkey=primer_bind
+NC_001802.1	RefSeq	gene	336	4642	.	+	.	ID=gene-HIV1gp1;Dbxref=GeneID:155348;Name=gag-pol;gbkey=Gene;gene=gag-pol;gene_biotype=protein_coding;locus_tag=HIV1gp1
+NC_001802.1	RefSeq	CDS	336	1637	.	+	0	ID=cds-NP_057849.4;Parent=gene-HIV1gp1;Dbxref=Genbank:NP_057849.4,GeneID:155348;Name=NP_057849.4;Note=Pr160;exception=ribosomal slippage;gbkey=CDS;gene=gag-pol;locus_tag=HIV1gp1;product=Gag-Pol;protein_id=NP_057849.4
+NC_001802.1	RefSeq	CDS	1637	4642	.	+	0	ID=cds-NP_057849.4;Parent=gene-HIV1gp1;Dbxref=Genbank:NP_057849.4,GeneID:155348;Name=NP_057849.4;Note=Pr160;exception=ribosomal slippage;gbkey=CDS;gene=gag-pol;locus_tag=HIV1gp1;product=Gag-Pol;protein_id=NP_057849.4
+NC_001802.1	RefSeq	gene	336	1838	.	+	.	ID=gene-HIV1gp2;Dbxref=GeneID:155030;Name=gag;gbkey=Gene;gene=gag;gene_biotype=protein_coding;locus_tag=HIV1gp2
+NC_001802.1	RefSeq	CDS	336	1838	.	+	0	ID=cds-NP_057850.1;Parent=gene-HIV1gp2;Dbxref=Genbank:NP_057850.1,GeneID:155030;Name=NP_057850.1;gbkey=CDS;gene=gag;locus_tag=HIV1gp2;product=Pr55(Gag);protein_id=NP_057850.1
+NC_001802.1	RefSeq	gene	4587	5165	.	+	.	ID=gene-HIV1gp3;Dbxref=GeneID:155459;Name=vif;gbkey=Gene;gene=vif;gene_biotype=protein_coding;locus_tag=HIV1gp3
+NC_001802.1	RefSeq	CDS	4587	5165	.	+	0	ID=cds-NP_057851.1;Parent=gene-HIV1gp3;Dbxref=Genbank:NP_057851.1,GeneID:155459;Name=NP_057851.1;gbkey=CDS;gene=vif;locus_tag=HIV1gp3;product=Vif;protein_id=NP_057851.1
+NC_001802.1	RefSeq	gene	5105	5396	.	+	.	ID=gene-HIV1gp4;Dbxref=GeneID:155807;Name=vpr;gbkey=Gene;gene=vpr;gene_biotype=protein_coding;locus_tag=HIV1gp4
+NC_001802.1	RefSeq	CDS	5105	5319	.	+	0	ID=cds-NP_057852.2;Parent=gene-HIV1gp4;Dbxref=Genbank:NP_057852.2,GeneID:155807;Name=NP_057852.2;Note=An artificial frameshift eliminating the orf-disrupting nucleotide at position 5320 is introduced to obtain the typical HIV-1 Vpr protein sequence. For this particular HIV-1 strain%2C HXB2%2C only a short (78 amino acid long) variant of the Vpr sequence can be obtained by translation of nucleotides 5105 through 5341 without the frameshift;exception=artificial frameshift;gbkey=CDS;gene=vpr;locus_tag=HIV1gp4;product=Vpr;protein_id=NP_057852.2
+NC_001802.1	RefSeq	CDS	5321	5396	.	+	1	ID=cds-NP_057852.2;Parent=gene-HIV1gp4;Dbxref=Genbank:NP_057852.2,GeneID:155807;Name=NP_057852.2;Note=An artificial frameshift eliminating the orf-disrupting nucleotide at position 5320 is introduced to obtain the typical HIV-1 Vpr protein sequence. For this particular HIV-1 strain%2C HXB2%2C only a short (78 amino acid long) variant of the Vpr sequence can be obtained by translation of nucleotides 5105 through 5341 without the frameshift;exception=artificial frameshift;gbkey=CDS;gene=vpr;locus_tag=HIV1gp4;product=Vpr;protein_id=NP_057852.2
+NC_001802.1	RefSeq	gene	5377	7970	.	+	.	ID=gene-HIV1gp5;Dbxref=GeneID:155871;Name=tat;gbkey=Gene;gene=tat;gene_biotype=protein_coding;locus_tag=HIV1gp5
+NC_001802.1	RefSeq	CDS	5377	5591	.	+	0	ID=cds-NP_057853.1;Parent=gene-HIV1gp5;Dbxref=Genbank:NP_057853.1,GeneID:155871;Name=NP_057853.1;Note=the length of Tat varies depending on virus strain or clade;gbkey=CDS;gene=tat;locus_tag=HIV1gp5;product=Tat;protein_id=NP_057853.1
+NC_001802.1	RefSeq	CDS	7925	7970	.	+	1	ID=cds-NP_057853.1;Parent=gene-HIV1gp5;Dbxref=Genbank:NP_057853.1,GeneID:155871;Name=NP_057853.1;Note=the length of Tat varies depending on virus strain or clade;gbkey=CDS;gene=tat;locus_tag=HIV1gp5;product=Tat;protein_id=NP_057853.1
+NC_001802.1	RefSeq	gene	5516	8199	.	+	.	ID=gene-HIV1gp6;Dbxref=GeneID:155908;Name=rev;gbkey=Gene;gene=rev;gene_biotype=protein_coding;locus_tag=HIV1gp6
+NC_001802.1	RefSeq	CDS	5516	5591	.	+	0	ID=cds-NP_057854.1;Parent=gene-HIV1gp6;Dbxref=Genbank:NP_057854.1,GeneID:155908;Name=NP_057854.1;gbkey=CDS;gene=rev;locus_tag=HIV1gp6;product=Rev;protein_id=NP_057854.1
+NC_001802.1	RefSeq	CDS	7925	8199	.	+	2	ID=cds-NP_057854.1;Parent=gene-HIV1gp6;Dbxref=Genbank:NP_057854.1,GeneID:155908;Name=NP_057854.1;gbkey=CDS;gene=rev;locus_tag=HIV1gp6;product=Rev;protein_id=NP_057854.1
+NC_001802.1	RefSeq	gene	5608	5856	.	+	.	ID=gene-HIV1gp7;Dbxref=GeneID:155945;Name=vpu;gbkey=Gene;gene=vpu;gene_biotype=protein_coding;locus_tag=HIV1gp7
+NC_001802.1	RefSeq	CDS	5608	5856	.	+	0	ID=cds-NP_057855.1;Parent=gene-HIV1gp7;Dbxref=Genbank:NP_057855.1,GeneID:155945;Name=NP_057855.1;Note=Vpu and gp160 are translated from different reading frames of the same bicistronic mRNA;gbkey=CDS;gene=vpu;locus_tag=HIV1gp7;product=Vpu;protein_id=NP_057855.1
+NC_001802.1	RefSeq	gene	5771	8341	.	+	.	ID=gene-HIV1gp8;Dbxref=GeneID:155971;Name=env;gbkey=Gene;gene=env;gene_biotype=protein_coding;locus_tag=HIV1gp8
+NC_001802.1	RefSeq	CDS	5771	8341	.	+	0	ID=cds-NP_057856.1;Parent=gene-HIV1gp8;Dbxref=Genbank:NP_057856.1,GeneID:155971;Name=NP_057856.1;gbkey=CDS;gene=env;locus_tag=HIV1gp8;product=Envelope surface glycoprotein gp160%2C precursor;protein_id=NP_057856.1
+NC_001802.1	RefSeq	gene	6919	7488	.	-	.	ID=gene-HIV1gp10;Dbxref=GeneID:19424028;Name=asp;gbkey=Gene;gene=asp;gene_biotype=protein_coding;locus_tag=HIV1gp10
+NC_001802.1	RefSeq	CDS	6919	7488	.	-	0	ID=cds-YP_009028572.1;Parent=gene-HIV1gp10;Dbxref=Genbank:YP_009028572.1,GeneID:19424028;Name=YP_009028572.1;gbkey=CDS;gene=asp;locus_tag=HIV1gp10;product=Asp;protein_id=YP_009028572.1
+NC_001802.1	RefSeq	gene	8343	8963	.	+	.	ID=gene-HIV1gp9;Dbxref=GeneID:156110;Name=nef;gbkey=Gene;gene=nef;gene_biotype=protein_coding;locus_tag=HIV1gp9
+NC_001802.1	RefSeq	CDS	8343	8963	.	+	0	ID=cds-NP_057857.2;Parent=gene-HIV1gp9;Dbxref=Genbank:NP_057857.2,GeneID:156110;Name=NP_057857.2;Note=This particular nucleotide sequence has a premature stop codon in place of a well-conserved tryptophan codon at position 8712-8714 that truncates the HIV1 Nef protein sequence to a 123 amino acids-long N-terminal portion (not shown).;gbkey=CDS;gene=nef;locus_tag=HIV1gp9;product=Nef;protein_id=NP_057857.2;transl_except=(pos:8712..8714%2Caa:Trp)
+NC_001802.1	RefSeq	three_prime_UTR	8631	9085	.	+	.	ID=id-NC_001802.1:8631..9085;gbkey=3'UTR
+NC_001802.1	RefSeq	region	9086	9181	.	+	.	ID=id-NC_001802.1:9086..9181;Note=repeat%3B positions of RNA transcription initialization and polyadenylation;gbkey=Region
+NC_001802.1	RefSeq	polyA_signal_sequence	9158	9163	.	+	.	ID=id-NC_001802.1:9158..9163;Note=both 5' and 3' poly A signals are transcribed into RNA%2C but the 5' one is suppressed;gbkey=regulatory;regulatory_class=polyA_signal_sequence
+###

--- a/references/metainfo.yaml
+++ b/references/metainfo.yaml
@@ -1,0 +1,2 @@
+gff:
+  GCF_000864765.1_ViralProj15476_genomic: HIV-1 HXB2 annotations

--- a/vpipe.config
+++ b/vpipe.config
@@ -2,15 +2,18 @@
 samples_file = samples.tsv
 fastq_suffix =
 
-gff_directory = references/gffs/
+;# uncomment to use HIV-1 genome annotations in visualization
+;metainfo_file = references/metainfo.yaml
+;gff_directory = references/gffs/
 primers_file =
+
 
 [output]
 snv = False
 local = False
 global = False
 
-visualization = True
+visualization = False
 
 [hmm_align]
 leave_msa_temp = true


### PR DESCRIPTION
This PR depends on #62 

It adds HIV annotations and sets default in the config file
(Visualization False by default, as it depends on SNVs and HIV specific anotations commented out)