### PR TITLE
Create a Dockerfile for V-pipe

### DIFF
--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -1,0 +1,21 @@
+name: Deploy Docker image
+
+on:
+  push:
+    branches: master
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Push to GitHub Packages
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          repository: cbg-ethz/V-pipe/v-pipe
+          tags: latest

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -17,5 +17,5 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: docker.pkg.github.com
-          repository: cbg-ethz/V-pipe/v-pipe
+          repository: cbg-ethz/v-pipe/v-pipe
           tags: latest

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -2,7 +2,7 @@ name: Deploy Docker image
 
 on:
   push:
-    branches: master
+    branches: [master, feature-docker]
 
 jobs:
   push_to_registry:

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -2,20 +2,33 @@ name: Deploy Docker image
 
 on:
   push:
-    branches: [master, feature-docker]
+    branches: [master]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  push_to_registry:
-    name: Push Docker image to GitHub Packages
+  docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v2
-      - name: Push to GitHub Packages
-        uses: docker/build-push-action@v1
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
-          repository: cbg-ethz/v-pipe/v-pipe
-          tags: latest
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: cbg-ethz/v-pipe:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM continuumio/miniconda:4.7.12
+FROM debian:stable
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
     curl \
  && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ RUN curl -O "https://raw.githubusercontent.com/cbg-ethz/V-pipe/master/utils/quic
     && bash quick_install.sh -b master -p /V-pipe_source -w /V-pipe_workdir
 
 WORKDIR /V-pipe_workdir
-RUN \
-    ./vpipe -j 1 --conda-create-envs-only
+RUN ln -s /V-pipe_source/V-pipe/testdata/ samples \
+    && ./vpipe -j 1 --conda-create-envs-only --conda-prefix /conda_prefix
 
 VOLUME /V-pipe
 WORKDIR /V-pipe
 
-ENTRYPOINT ["/V-pipe_workdir/vpipe"]
+ENTRYPOINT ["/V-pipe_workdir/vpipe", "--conda-prefix", "/conda_prefix"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
  && rm -rf /var/lib/apt/lists/*
 
-RUN \
-    curl -O "https://raw.githubusercontent.com/cbg-ethz/V-pipe/master/utils/quick_install.sh" && \
-    bash quick_install.sh -b master -p /V-pipe_source -w /V-pipe_workdir
+RUN curl -O "https://raw.githubusercontent.com/cbg-ethz/V-pipe/master/utils/quick_install.sh" \
+    && bash quick_install.sh -b master -p /V-pipe_source -w /V-pipe_workdir
 
 WORKDIR /V-pipe_workdir
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN \
     curl -O "https://raw.githubusercontent.com/cbg-ethz/V-pipe/master/utils/quick_install.sh" && \
-    bash quick_install.sh -b master -p /V-pipe_source -w /V-pipe
+    bash quick_install.sh -b master -p /V-pipe_source -w /V-pipe_workdir
 
-WORKDIR /V-pipe
+WORKDIR /V-pipe_workdir
 RUN \
     ./vpipe -j 1 --conda-create-envs-only
 
-VOLUME /V-pipe_input
+VOLUME /V-pipe
+WORKDIR /V-pipe
 
-ENTRYPOINT ["/V-pipe/vpipe"]
+ENTRYPOINT ["/V-pipe_workdir/vpipe"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM continuumio/miniconda:4.7.12
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN \
+    curl -O "https://raw.githubusercontent.com/cbg-ethz/V-pipe/master/utils/quick_install.sh" && \
+    bash quick_install.sh -b master -p /V-pipe_source -w /V-pipe
+
+WORKDIR /V-pipe
+RUN \
+    ./vpipe -j 1 --conda-create-envs-only
+
+VOLUME /V-pipe_input
+
+ENTRYPOINT ["/V-pipe/vpipe"]

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ Make sure to use `source activate V-pipe` everytime you want to run V-pipe
 git clone https://github.com/cbg-ethz/V-pipe.git /path/to/V-pipe
 ```
 
+### Docker
+
+```bash
+docker build -t vpipe . # to be replaced with link to registry
+docker run -v $PWD:/V-pipe_input vpipe
+```
+
 ## Running V-pipe
 
 First, open a terminal and change into the **working directory** where input files are stored (i.e., the reference and the sequencing reads). We use a [two-level](https://github.com/cbg-ethz/V-pipe/wiki/getting-started#input-files) directory hierarchy and we expect sequencing reads in a folder name `raw_data`. To initialize a project,
@@ -82,7 +89,7 @@ Further details can be found in the [wiki](https://github.com/cbg-ethz/V-pipe/wi
 
   VICUNA is a *de novo* assembly software designed for populations with high mutation rates. It is used to build an initial reference for mapping reads with ngshmmalign aligner when a `references/cohort_consensus.fasta` file is not provided. Further details can be found in the [wiki](https://github.com/cbg-ethz/V-pipe/wiki/getting-started#input-files) pages.
 
-### Computational tools 
+### Computational tools
 Other dependencies are managed by using isolated conda environments per rule, and below we list some of the computational tools integrated in V-pipe:
 
 - **PRINSEQ**

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ git clone https://github.com/cbg-ethz/V-pipe.git /path/to/V-pipe
 
 ```bash
 docker build -t vpipe . # to be replaced with link to registry
-docker run -v $PWD:/V-pipe_input vpipe
+docker run -v $PWD:/V-pipe vpipe
 ```
 
 ## Running V-pipe

--- a/README.md
+++ b/README.md
@@ -55,9 +55,27 @@ git clone https://github.com/cbg-ethz/V-pipe.git /path/to/V-pipe
 
 ### Docker
 
+Note: the docker image is only setup with components to run the workflow for HIV and SARS-CoV-2.
+Using V-pipe with other viruses might require internet connectivity for additional software components.
+
+Populate the `samples` directory and create `config.yaml` or `vpipe.config`.
+For example, the following config file could be used:
+```yaml
+general:
+  virus_base_config: hiv
+
+output:
+  snv: true
+  local: true
+  global: false
+  visualization: true
+  QA: true
+```
+
+Then execute:
+
 ```bash
-docker build -t vpipe . # to be replaced with link to registry
-docker run -v $PWD:/V-pipe vpipe
+docker run -v $PWD:/work ghcr.io/cbg-ethz/vpipe:latest -j 4
 ```
 
 ## Running V-pipe


### PR DESCRIPTION
This PR proposes to allow the distribution of V-pipe via Docker.

Some topics which need to be discussed:
* how to handle mounting volumes and modifying the default `vpipe.config` file
* whether to automatically [publish](https://docs.github.com/en/free-pro-team@latest/actions/guides/publishing-docker-images#publishing-images-to-github-packages) the images using GitHub Actions
* which base image is the most suitable

Related: https://github.com/cbg-ethz/V-pipe/issues/21