### PR TITLE
Fix input file of rule 'create_simple_initial'

### DIFF
--- a/rules/align.smk
+++ b/rules/align.smk
@@ -183,7 +183,7 @@ localrules:
     create_simple_initial
 rule create_simple_initial:
     input:
-        "references/cohort_consensus.fasta"
+        config.input["reference"]
     output:
         "{dataset}/references/initial_consensus.fasta"
     shell:


### PR DESCRIPTION
This PR changes the input file of the rule `create_simple_initial ` to the reference file set in `vpipe.config` (as discussed with @DrYak).
Otherwise, even if the reference exists, vicuna tries to run.