### PR TITLE
temp_prefix and shadow rules

### DIFF
--- a/rules/align.smk
+++ b/rules/align.smk
@@ -226,9 +226,9 @@ ruleorder:
 # 2. aligning
 def input_align(wildcards):
     list_output = []
-    list_output.append(config.general["temp_prefix"] + wildcards.dataset + "/preprocessed_data/R1.fastq")
+    list_output.append(os.path.join(config.general["temp_prefix"], wildcards.dataset, "preprocessed_data/R1.fastq"))
     if config.input['paired']:
-        list_output.append(config.general["temp_prefix"] + wildcards.dataset + "/preprocessed_data/R2.fastq")
+        list_output.append(os.path.join(config.general["temp_prefix"], wildcards.dataset, "preprocessed_data/R2.fastq"))
     return(list_output)
 
 

--- a/rules/align.smk
+++ b/rules/align.smk
@@ -226,9 +226,9 @@ ruleorder:
 # 2. aligning
 def input_align(wildcards):
     list_output = []
-    list_output.append(wildcards.dataset + "/preprocessed_data/R1.fastq")
+    list_output.append(config.general["temp_prefix"] + wildcards.dataset + "/preprocessed_data/R1.fastq")
     if config.input['paired']:
-        list_output.append(wildcards.dataset + "/preprocessed_data/R2.fastq")
+        list_output.append(config.general["temp_prefix"] + wildcards.dataset + "/preprocessed_data/R2.fastq")
     return(list_output)
 
 
@@ -489,7 +489,7 @@ elif config.general["aligner"] == "bowtie":
                 TMP_SAM = "{dataset}/alignments/tmp_aln.sam",
                 PHRED = config.bowtie_align['phred'],
                 PRESET = config.bowtie_align['preset'],
-                MAXINS = get_maxins, 
+                MAXINS = get_maxins,
                 EXTRA = config.bowtie_align['extra'],
                 BOWTIE = config.applications['bowtie'],
                 SAMTOOLS = config.applications['samtools'],
@@ -596,4 +596,3 @@ elif config.general["aligner"] == "bwa":
 elif config.general["aligner"] == "bowtie":
     ruleorder: consensus_sequences > hmm_align
     ruleorder: sam2bam > convert_to_ref
-

--- a/rules/config_default.smk
+++ b/rules/config_default.smk
@@ -43,7 +43,8 @@ class VpipeConfig(object):
             'threads': __RECORD__(value=4, type=int),
             'aligner': __RECORD__(value='ngshmmalign', type=str),
             'snv_caller': __RECORD__(value='shorah', type=str),
-            'haplotype_reconstruction': __RECORD__(value='savage', type=str)
+            'haplotype_reconstruction': __RECORD__(value='savage', type=str),
+            'temp_prefix': __RECORD__(value='', type=str),  # path must end with '/'
         }),
         ('input', {
             'datadir': __RECORD__(value='samples', type=str),
@@ -309,7 +310,7 @@ class VpipeConfig(object):
         self._vpipe_configfile = configparser.ConfigParser()
         self._vpipe_configfile.read('vpipe.config')
 
-        # clone to validate vpipe.config file 
+        # clone to validate vpipe.config file
         vpipe_configfile = configparser.ConfigParser()
         vpipe_configfile.read('vpipe.config')
 

--- a/rules/quality_assurance.smk
+++ b/rules/quality_assurance.smk
@@ -11,7 +11,7 @@ rule gunzip:
     input:
         "{file}.{ext}.gz"
     output:
-        temp(config.general["temp_prefix"] + "{file}.{ext,(fastq|fq)}")
+        temp(os.path.join(config.general["temp_prefix"], "{file}.{ext,(fastq|fq)}"))
     params:
         scratch = '10000',
         mem = config.gunzip['mem'],
@@ -31,7 +31,7 @@ rule extract:
     input:
         construct_input_fastq
     output:
-        temp(config.general["temp_prefix"] + "{dataset}/extracted_data/R{pair}.fastq")
+        temp(os.path.join(config.general["temp_prefix"], "{dataset}/extracted_data/R{pair}.fastq"))
     params:
         scratch = '2000',
         mem = config.extract['mem'],
@@ -63,8 +63,8 @@ def len_cutoff(wildcards):
 if config.input['paired']:
     rule preprocessing:
         input:
-            R1 = config.general["temp_prefix"] + "{dataset}/extracted_data/R1.fastq",
-            R2 = config.general["temp_prefix"] + "{dataset}/extracted_data/R2.fastq",
+            R1 = os.path.join(config.general["temp_prefix"], "{dataset}/extracted_data/R1.fastq"),
+            R2 = os.path.join(config.general["temp_prefix"], "{dataset}/extracted_data/R2.fastq"),
         output:
             R1gz = "{dataset}/preprocessed_data/R1.fastq.gz",
             R2gz = "{dataset}/preprocessed_data/R2.fastq.gz"
@@ -110,7 +110,7 @@ if config.input['paired']:
 else:
     rule preprocessing_se:
         input:
-            R1 = config.general["temp_prefix"] + "{dataset}/extracted_data/R1.fastq",
+            R1 = os.path.join(config.general["temp_prefix"], "{dataset}/extracted_data/R1.fastq"),
         output:
             R1gz = "{dataset}/preprocessed_data/R1.fastq.gz",
         params:
@@ -154,7 +154,7 @@ else:
 # 3. QC reports
 rule fastqc:
     input:
-        config.general["temp_prefix"] + "{dataset}/extracted_data/R{pair}.fastq",
+        os.path.join(config.general["temp_prefix"], "{dataset}/extracted_data/R{pair}.fastq"),
     output:
         "{dataset}/extracted_data/R{pair}_fastqc.html",
     params:


### PR DESCRIPTION
This PR adds a parameter `temp_prefix` to the `general` configuration section. It specifies a directory where extracted (intermediate) FASTQ files will be stored.

In addition, `preprocessing` is now a minimal shadow rule. The base shadow directory can be changed with the `--shadow-prefix` command line argument.