### PR TITLE
S3C-SIS-TASK-11: Consensus sequences need to be manually imported.

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -19,6 +19,7 @@ functions = srcdir("scripts/functions.sh")
 rule all:
     input:
         all_files,
+        "summary.json"
 
 
 rule alltrimmed:
@@ -37,6 +38,7 @@ include: "rules/align.smk"
 include: "rules/consensus.smk"
 include: "rules/mafs.smk"
 include: "rules/stats.smk"
+include: "rules/publish.smk"
 
 
 if config.output["snv"] or config.output["local"]:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -19,7 +19,7 @@ functions = srcdir("scripts/functions.sh")
 rule all:
     input:
         all_files,
-        "summary.json"
+        "summary.json",
 
 
 rule alltrimmed:

--- a/workflow/envs/report_sequences.yaml
+++ b/workflow/envs/report_sequences.yaml
@@ -1,0 +1,4 @@
+channels:
+  - conda-forge
+dependencies:
+  - biopython

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -6,8 +6,11 @@ __email__ = "v-pipe@bsse.ethz.ch"
 
 import csv
 import os
+import pathlib
 import re
 import typing
+
+from datetime import datetime, timezone
 
 # for legacy
 import configparser
@@ -365,6 +368,7 @@ for p in patient_list:
     references.append(os.path.join(sdir, "references/ref_"))
 
     consensus.append(os.path.join(sdir, "references/ref_ambig.fasta"))
+    consensus.append(os.path.join(sdir, "references/ref_ambig_dels.fasta"))
     consensus.append(os.path.join(sdir, "references/ref_majority.fasta"))
 
     consensus.append(os.path.join(sdir, "references/consensus.bcftools.fasta"))

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -252,6 +252,7 @@ def process_config(config):
     e.g.  config.input instead of config["input"] so we don't have to change
     all existing rules.
     """
+
     def wrap(dd):
         if isinstance(dd, dict):
             dd = UserDict(dd)

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -245,15 +245,19 @@ def process_config(config):
                 section[entry] = value.format(VPIPE_BASEDIR=VPIPE_BASEDIR)
 
     """
-    The following hack supports `.` access to dictionary entries, e.g.
-    config.input instead of config["input"] so we don't have to change all
-    existing rules.
-    This works only on the upper-level of config and not for the nested
-    dictionaries.
+    The following hack supports `.` access to recursive dictionary entries,
+    e.g.  config.input instead of config["input"] so we don't have to change
+    all existing rules.
     """
-    config = UserDict(config)
-    config.__dict__.update(config)
-    return config
+    def wrap(dd):
+        if isinstance(dd, dict):
+            dd = UserDict(dd)
+            for k, v in dd.items():
+                dd[k] = wrap(v)
+            dd.__dict__.update(dd)
+        return dd
+
+    return wrap(config)
 
 
 config = process_config(config)

--- a/workflow/rules/consensus.smk
+++ b/workflow/rules/consensus.smk
@@ -132,8 +132,6 @@ rule consensus_sequences:
         """
 
 
-
-
 # QA checks performed on consensus_sequences
 # - do pairwise alignement
 rule consseq_QA:

--- a/workflow/rules/consensus.smk
+++ b/workflow/rules/consensus.smk
@@ -132,6 +132,8 @@ rule consensus_sequences:
         """
 
 
+
+
 # QA checks performed on consensus_sequences
 # - do pairwise alignement
 rule consseq_QA:

--- a/workflow/rules/haplotypes.smk
+++ b/workflow/rules/haplotypes.smk
@@ -162,9 +162,9 @@ if config.input["paired"]:
                     config.output["datadir"],
                     config.output["cohortdir"],
                     "cohort_consensus.fasta",
-                )
-                if config[
-                    "lofreq" if config.general["snv_caller"] == "lofreq" else "snv"
+            )
+            if config[
+            "lofreq" if config.general["snv_caller"] == "lofreq" else "snv"
                 ]["consensus"]
                 else reference_file
             ),

--- a/workflow/rules/publish.smk
+++ b/workflow/rules/publish.smk
@@ -1,0 +1,12 @@
+rule write_summary_json:
+    input:
+        lambda wildcard: [f for f in all_files if f.endswith("ref_ambig_dels.fasta")]
+    output:
+        "summary.json"
+    conda:
+        config.report_sequences["conda"]
+    shell:
+        # needed {CONDA_PREFIX} on my dev setup on Mac + pyenv:
+        """
+        ${{CONDA_PREFIX}}/bin/python {VPIPE_BASEDIR}/scripts/report_sequences.py {input}
+        """

--- a/workflow/rules/publish.smk
+++ b/workflow/rules/publish.smk
@@ -1,8 +1,8 @@
 rule write_summary_json:
     input:
-        lambda wildcard: [f for f in all_files if f.endswith("ref_ambig_dels.fasta")]
+        lambda wildcard: [f for f in all_files if f.endswith("ref_ambig_dels.fasta")],
     output:
-        "summary.json"
+        "summary.json",
     conda:
         config.report_sequences["conda"]
     shell:

--- a/workflow/rules/visualization.smk
+++ b/workflow/rules/visualization.smk
@@ -19,9 +19,9 @@ rule generate_web_visualization:
                 config.output["datadir"],
                 config.output["cohortdir"],
                 "cohort_consensus.fasta",
-            )
-            if config["lofreq" if config.general["snv_caller"] == "lofreq" else "snv"][
-                "consensus"
+        )
+        if config["lofreq" if config.general["snv_caller"] == "lofreq" else "snv"][
+        "consensus"
             ]
             else reference_file
         ),

--- a/workflow/schemas/config_schema.json
+++ b/workflow/schemas/config_schema.json
@@ -1081,6 +1081,16 @@
             },
             "default": {},
             "type": "object"
+        },
+        "report_sequences": {
+            "properties": {
+                "conda": {
+                    "type": "string",
+                    "default": "{VPIPE_BASEDIR}/envs/report_sequences.yaml"
+                }
+            },
+            "default": {},
+            "type": "object"
         }
     }
 }

--- a/workflow/scripts/report_sequences.py
+++ b/workflow/scripts/report_sequences.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import hashlib
+import pathlib
+import json
+import sys
+from datetime import datetime, timezone
+
+from Bio import SeqIO
+from Bio.SeqUtils.CheckSum import seguid, crc64
+
+LOCAL_TIMEZONE = datetime.now(timezone.utc).astimezone().tzinfo
+
+results = []
+
+for f in sys.argv[1:]:
+    f = pathlib.Path(f)
+    _, sample, batch, *_ = f.parts
+
+    timestamp = datetime.fromtimestamp(f.stat().st_ctime, tz=LOCAL_TIMEZONE)
+    sequences = []
+    for record in SeqIO.parse(f, "fasta"):
+        sequence = record.seq
+        sequences.append(
+            dict(
+                header=record.id,
+                seguid=seguid(sequence),
+                crc64=crc64(sequence),
+                sequence=str(sequence),
+            )
+        )
+    results.append(
+        dict(sample=sample, batch=batch, created=str(timestamp), sequences=sequences)
+    )
+
+with open("summary.json", "w") as fh:
+    json.dump(results, fh, indent=4)


### PR DESCRIPTION
Relates to issue https://gitlab.ethz.ch/sars_cov_2/s3c-it-tasks/-/issues/11

- I forked from `rubicon` branch since this was the branch I found on euler
- I tried to extend V-pipe to collect the consensus sequences at the end of each run and to compute/determine for the sequences:
    - batch / sample id (based on path) of `﻿﻿﻿ref_ambig_dels.fasta`
    - creation time stamp of  `ref_ambig_dels.fasta`
    - seguid and crc64 checksum for each sequence in `ref_ambig_dels.fasta`.

The rule finally writes a file `summary.json` to the current working directory.

This is an initial attempt replace the manually triggered import script without coupling V-pipe to the infrastructure of the overall  S3C workflow. 

This pull request is accompanied by https://github.com/cbg-ethz/pangolin/pull/3 which includes a script to read the created `summary.json` file and uploads it to the S3C database. 

Future work will be to complete the information in `summary.json`.


