### PR TITLE
[FEAT] Added sftp sync staging

### DIFF
--- a/utils/sort_samples_dumb
+++ b/utils/sort_samples_dumb
@@ -78,7 +78,7 @@ done
 : "${batch_name:?missing mandatory batch name, use option -b}"
 : "${out_dir:?missing mandatory output dir use option -o}"
 
-: "${tsv:=${out_dir}/samples.${batch_name}.tsv}"
+: "${tsv:=${out_dir}/samples.${batch_name}.tsv.staging}"
 
 
 # RegEx
@@ -225,9 +225,11 @@ if (( numdup )); then
 	fi
 fi
 if (( ALLOK )); then
-	info All Ok
-	exit 0
+        mv -v ${tsv} ${tsv//\.staging/}
+        info All Ok
+        exit 0
 else
-	warn Some errors
-	exit 1
+        warn Some errors
+        exit 1
 fi
+

--- a/utils/sort_samples_jobinfo
+++ b/utils/sort_samples_jobinfo
@@ -136,7 +136,7 @@ if not os.path.isdir(sampleset):
 
 # output files
 batch=f"{date}_{flowcell}"
-tsv=open(os.path.join(sampleset,f'samples.{batch}.tsv'), 'wt')
+tsv=open(os.path.join(sampleset,f'samples.{batch}.tsv.staging'), 'wt')
 # shell script file with all moving instructions inside
 sh=open(os.path.join(sampleset,'movedatafiles.sh'), 'at' if append else 'wt')
 
@@ -232,13 +232,17 @@ if args.batch:
 
 # coda: return status
 if not append: print(f"""
-if (( ALLOK )); then
-	echo All Ok
-	exit 0
-else
-	echo Some errors
-	exit 1
+if (( !ALLOK )); then
+        echo Some errors
+        exit 1
 fi;
+
 """, file=sh)
 
-sys.exit(0)
+print(f"mv -v {sampleset}/sample.{batch}.tsv.staging samples {sampleset}/sample.{batch}.tsv", file=sh)
+
+print("""
+echo All Ok
+exit 0
+""", file=sh)
+


### PR DESCRIPTION
Added a staging file for `samples.<batch>.tsv` with the `.staging` suffix. Only when the entire procedure detailed in `sort_samples_*` is successful the file is renamed.
This ensures that syncing problems do not lead to an inconsistent cohort, as anything in the staging file is not processed