### PR TITLE
Snakemake workflow catalog standardized usage

### DIFF
--- a/.snakemake-workflow-catalog.yml
+++ b/.snakemake-workflow-catalog.yml
@@ -1,0 +1,6 @@
+usage:
+  software-stack-deployment:
+    conda: true
+    singularity: false
+    singularity+conda: false
+  report: false


### PR DESCRIPTION
Add `.snakemake-workflow-catalog.yml` file for configuring usage instructions for the [Snakemake Workflow Catalog](https://snakemake.github.io/snakemake-workflow-catalog)

Fixes #151 