### PR TITLE
Enable Parallel Deconvolution in Lollipop

### DIFF
--- a/workflow/envs/lollipop.yaml
+++ b/workflow/envs/lollipop.yaml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - lollipop =0.4.1
+  - lollipop =0.4.2

--- a/workflow/rules/signatures.smk
+++ b/workflow/rules/signatures.smk
@@ -362,7 +362,7 @@ rule deconvolution:
     threads: config.deconvolution["threads"]
     shell:
         """
-        {params.LOLLIPOP} deconvolute "--output={output.deconvoluted}" "--out-json={output.deconv_json}" "--var={input.var_conf}" "--vd={input.var_dates}" "--dec={input.deconv_conf}" "--filters={input.filters}" {params.out_format} {params.seed} "{input.tallymut}" 2> >(tee -a {log.errfile} >&2) > >(tee -a {log.outfile})
+        {params.LOLLIPOP} deconvolute "--output={output.deconvoluted}" "--out-json={output.deconv_json}" "--var={input.var_conf}" "--vd={input.var_dates}" "--dec={input.deconv_conf}" "--filters={input.filters}" {params.out_format} --seed={params.seed} --n-cores={threads} "{input.tallymut}" 2> >(tee -a {log.errfile} >&2) > >(tee -a {log.outfile})
         """
 
 


### PR DESCRIPTION
This PR enables parallel processing for the deconvolution by Lollipop. The deconvolution can now be done in parallel for each location.

 To consider:
- [ ] Ensure correct Versioning of Lollipop 
- [ ] Adding a note in the V-Pipe Docs on the recommended number of cores for the deconvolution