### PR TITLE
automation: adding `dependabot` for github actions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,13 @@
+# Dependabot for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "rubicon"
+    commit-message:
+      prefix: "GitHub Actions"
+      include: "scope"


### PR DESCRIPTION
Dependabot itself already implements the functionality to keep GitHub actions up to date.

This PR implements a minimal viable dependabot workflow to update:
- Github Actions only
- on a weekly basis
- pointing the PR to our dev branch `rubicon`
- Call the commit message `Github Actions: <<action updated>>`

Optinally, we may want to `labels` to the workflow to add labels to the PR (we'd have to add these to the repo) 
```
    labels:
      - "dependencies"
      - "github-actions"
```