### PR TITLE
Covvfit integration

### DIFF
--- a/workflow/envs/covvfit.yaml
+++ b/workflow/envs/covvfit.yaml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+dependencies:
+  - python>=3.11
+  - pip
+  - pip:
+    - covvfit

--- a/workflow/envs/covvfit.yaml
+++ b/workflow/envs/covvfit.yaml
@@ -1,7 +1,7 @@
 channels:
   - conda-forge
 dependencies:
-  - python>=3.11
+  - python=3.11
   - pip
   - pip:
     - covvfit

--- a/workflow/rules/signatures.smk
+++ b/workflow/rules/signatures.smk
@@ -383,7 +383,7 @@ rule deconvolution_nosmooth:
             if config.deconvolution["source"] == "cooc"
             else cohortdir("tallymut.tsv.zst")
         ),
-        deconv_conf=config.deconvolution["deconvolution_config"],
+        deconv_conf=config.covvfit["deconvolution_config"],
         var_conf=(
             config.deconvolution["variants_config"]
             if config.deconvolution["variants_config"]

--- a/workflow/rules/signatures.smk
+++ b/workflow/rules/signatures.smk
@@ -398,7 +398,7 @@ rule deconvolution_nosmooth:
             config.deconvolution["filters"] if config.deconvolution["filters"] else []
         ),
     output:
-        deconvoluted=cohortdir("deconvoluted_nosmooth.tsv.zst"),
+        deconvoluted=cohortdir("deconvoluted_nosmooth.csv"),
     params:
         LOLLIPOP=config.applications["lollipop"],
         seed="--seed=42",
@@ -416,12 +416,15 @@ rule deconvolution_nosmooth:
     threads: config.deconvolution["threads"]
     shell:
         """
-        {params.COVVFIT} infer \
-            -i "{input.deconvoluted}" \
-            -o "{params.outdir}" \
-            -c "{input.covvfit_conf}" \
-            --max-days "{params.max_days}" \
-            --horizon "{params.horizon}" \
+        {params.LOLLIPOP} deconvolute \
+            "--output={output.deconvoluted}" \
+            "--var={input.var_conf}" \
+            "--vd={input.var_dates}" \
+            "--dec={input.deconv_conf}" \
+            "--filters={input.filters}" \
+            {params.seed} \
+            "--n-cores={threads}" \
+            "{input.tallymut}" \
             2> >(tee -a {log.errfile} >&2) > >(tee -a {log.outfile})
         """
 

--- a/workflow/rules/signatures.smk
+++ b/workflow/rules/signatures.smk
@@ -454,6 +454,7 @@ rule covvfit:
     threads: config.covvfit["threads"]
     shell:
         """
+        # covvfit creates its own output dir; remove pre-created dir to avoid FileExistsError
         rm -rf "{params.outdir}" && \
         {params.COVVFIT} infer -i "{input.deconvoluted}" -o "{params.outdir}" -c "{input.covvfit_conf}" --max-days {params.max_days} --horizon {params.horizon} 2> >(tee -a {log.errfile} >&2) > >(tee -a {log.outfile})
         """

--- a/workflow/rules/signatures.smk
+++ b/workflow/rules/signatures.smk
@@ -376,6 +376,85 @@ rule deconvolution:
         {params.LOLLIPOP} deconvolute "--output={output.deconvoluted}" "--out-json={output.deconv_json}" "--var={input.var_conf}" "--vd={input.var_dates}" "--dec={input.deconv_conf}" "--filters={input.filters}" {params.out_format} {params.seed} {params.EXTRA} "--n-cores={threads}" "{input.tallymut}" 2> >(tee -a {log.errfile} >&2) > >(tee -a {log.outfile})
         """
 
+rule deconvolution_nosmooth:
+    input:
+        tallymut=(
+            cohortdir("tallycooc.tsv.zst")
+            if config.deconvolution["source"] == "cooc"
+            else cohortdir("tallymut.tsv.zst")
+        ),
+        deconv_conf=config.deconvolution["deconvolution_config"],
+        var_conf=(
+            config.deconvolution["variants_config"]
+            if config.deconvolution["variants_config"]
+            else cohortdir("variants_pangolin.yaml")
+        ),
+        var_dates=(
+            config.deconvolution["variants_dates"]
+            if config.deconvolution["variants_dates"]
+            else []
+        ),
+        filters=(
+            config.deconvolution["filters"] if config.deconvolution["filters"] else []
+        ),
+    output:
+        deconvoluted=cohortdir("deconvoluted_nosmooth.tsv.zst"),
+    params:
+        LOLLIPOP=config.applications["lollipop"],
+        seed="--seed=42",
+    log:
+        outfile=cohortdir("deconvoluted_nosmooth.out.log"),
+        errfile=cohortdir("deconvoluted_nosmooth.err.log"),
+    conda:
+        config.deconvolution["conda"]
+    benchmark:
+        cohortdir("deconvoluted_nosmooth.benchmark")
+    resources:
+        disk_mb=1024,
+        mem_mb=config.deconvolution["mem"],
+        runtime=config.deconvolution["time"],
+    threads: config.deconvolution["threads"]
+    shell:
+        """
+        {params.COVVFIT} infer \
+            -i "{input.deconvoluted}" \
+            -o "{params.outdir}" \
+            -c "{input.covvfit_conf}" \
+            --max-days "{params.max_days}" \
+            --horizon "{params.horizon}" \
+            2> >(tee -a {log.errfile} >&2) > >(tee -a {log.outfile})
+        """
+
+rule covvfit:
+    input:
+        deconvoluted=cohortdir("deconvoluted_nosmooth.csv"),
+        covvfit_conf=config.covvfit["config"],
+    output:
+        results=cohortdir("covvfit/results.yaml"),
+        pairwise=cohortdir("covvfit/pairwise_fitnesses.csv"),
+    params:
+        COVVFIT=config.applications["covvfit"],
+        outdir=lambda w, output: os.path.dirname(output.results),
+        max_days=config.covvfit["max_days"],
+        horizon=config.covvfit["horizon"],
+    log:
+        outfile=cohortdir("covvfit.out.log"),
+        errfile=cohortdir("covvfit.err.log"),
+    conda:
+        config.covvfit["conda"]
+    benchmark:
+        cohortdir("covvfit.benchmark"),
+    resources:
+        disk_mb=1024,
+        mem_mb=config.covvfit["mem"],
+        runtime=config.covvfit["time"],
+    threads: config.covvfit["threads"]
+    shell:
+        """
+        {params.COVVFIT} infer -i "{input.deconvoluted}" -o "params.outdir" -c "{input.covvfit_conf} --max_days {params.max_days} --horizon {params.horizon} 2> >(tee -a {log.errfile} >&2)  > >(tee -a {log.outfile})"
+        """
+
+
 
 def expand_proto(fmtstr, **kwargs):
     return expand(

--- a/workflow/rules/signatures.smk
+++ b/workflow/rules/signatures.smk
@@ -451,6 +451,7 @@ rule covvfit:
     threads: config.covvfit["threads"]
     shell:
         """
+        rm -rf "{params.outdir}" && \
         {params.COVVFIT} infer -i "{input.deconvoluted}" -o "{params.outdir}" -c "{input.covvfit_conf}" --max-days {params.max_days} --horizon {params.horizon} 2> >(tee -a {log.errfile} >&2) > >(tee -a {log.outfile})
         """
 

--- a/workflow/rules/signatures.smk
+++ b/workflow/rules/signatures.smk
@@ -451,7 +451,7 @@ rule covvfit:
     threads: config.covvfit["threads"]
     shell:
         """
-        {params.COVVFIT} infer -i "{input.deconvoluted}" -o "params.outdir" -c "{input.covvfit_conf} --max_days {params.max_days} --horizon {params.horizon} 2> >(tee -a {log.errfile} >&2)  > >(tee -a {log.outfile})"
+        {params.COVVFIT} infer -i "{input.deconvoluted}" -o "{params.outdir}" -c "{input.covvfit_conf}" --max-days {params.max_days} --horizon {params.horizon} 2> >(tee -a {log.errfile} >&2) > >(tee -a {log.outfile})
         """
 
 

--- a/workflow/schemas/config_schema.json
+++ b/workflow/schemas/config_schema.json
@@ -1801,7 +1801,7 @@
                 },
                 "max_days": {
                     "type": "integer",
-                    "default": 365,
+                    "default": 180,
                     "description": "Restrict the analysis to the most recent N days of data."
                 },
                 "horizon": {

--- a/workflow/schemas/config_schema.json
+++ b/workflow/schemas/config_schema.json
@@ -440,6 +440,10 @@
                 "lollipop": {
                     "type": "string",
                     "default": "lollipop"
+                },
+                "covvfit": {
+                    "type": "string",
+                    "default": "covvfit"
                 }
             },
             "default": {},
@@ -1761,6 +1765,49 @@
                     "default": "",
                     "description": "Pass additional options to run `lollipop deconvolute` such as, e.g., `--bp` (see [LolliPop README](https://github.com/cbg-ethz/LolliPop)).",
                     "examples": ["--bp 0"]
+                }
+            },
+            "default": {},
+            "type": "object"
+        },
+        "covvfit": {
+            "properties": {
+                "mem": {
+                    "type": "integer",
+                    "default": 8192
+                },
+                "time": {
+                    "type": "integer",
+                    "default": 60
+                },
+                "threads": {
+                    "type": "integer",
+                    "default": 1,
+                    "description": "Cores for covvfit inference"
+                },
+                "conda": {
+                    "type": "string",
+                    "default": "{VPIPE_BASEDIR}/envs/covvfit.yaml"
+                },
+                "deconvolution_config": {
+                    "type": "string",
+                    "default": "{VPIPE_BASEDIR}/../resources/covvfit/deconv_config_nosmooth.yaml",
+                    "description": "Lollipop deconvolution config with no smoothing, to prepare unbiased input for covvfit."
+                },
+                "config": {
+                    "type": "string",
+                    "default": "{VPIPE_BASEDIR}/../resources/covvfit/covvfit_config.yaml",
+                    "description": "covvfit configuration file (variants to track, plot settings)."
+                },
+                "max_days": {
+                    "type": "integer",
+                    "default": 365,
+                    "description": "Restrict the analysis to the most recent N days of data."
+                },
+                "horizon": {
+                    "type": "integer",
+                    "default": 90,
+                    "description": "Number of future days to forecast."
                 }
             },
             "default": {},


### PR DESCRIPTION
## Summary
Incorporated covvfit tool into v-pipe

Adds to new snakemake rules to signatures.smk

- "deconvolution_nosmooth": runs Lollipop deconvolution without kernel smoothing, which is required as input for covvfit.
- "covvfit": runs covvfit fitness inference on the deconvolution output.

Also adds:
- "workflow/envs/covvfit.yaml": conda environment for covvfit (python 3.11)
- schema additions for "covvfit" and "deconvolution_nosmooth"

## Testing
-Validated locally
-Validated end-to-end on Euler cluster via SLURM

